### PR TITLE
refactor: suggestions to make code more concise

### DIFF
--- a/metrics/grpcMetrics.js
+++ b/metrics/grpcMetrics.js
@@ -42,6 +42,8 @@ const grpcMetricsInterceptor = async (ctx, next) => {
   grpcRequestsInflight.inc({
     service, method
   })
+  // check this: https://stackoverflow.com/a/14551263/8694937
+  // maybe use process.hrtime() would more like a pro
   const start = new Date().getTime()
   try {
     await next()

--- a/metrics/index.js
+++ b/metrics/index.js
@@ -5,11 +5,9 @@ import grpcMetricsInterceptor from './grpcMetrics.js'
 import jsonLogger from '../logs/index.js'
 
 const defaultOptions = {
-  METRICS_PORT: 9090,
-  metricsPath: '/metrics',
-  collectDefaultMetrics: true,
-  httpMetricsMiddleware,
-  grpcMetricsInterceptor
+  port: 9090,
+  path: '/metrics',
+  collectDefaultMetrics: true
 }
 
 // workaround solution for silence reject
@@ -24,30 +22,27 @@ class Metrics {
   constructor (userOptions = {}) {
     const options = { ...defaultOptions, ...userOptions }
     const app = express()
-    app.get(options.metricsPath, asyncHandler(async (req, res, next) => {
+    app.get(options.path, asyncHandler(async (req, res, next) => {
       res.set('Content-Type', prometheus.register.contentType)
       res.send(await prometheus.register.metrics())
       const { originalUrl: urlPath, method } = req
       jsonLogger.info('User Visited', { exportToPrometheus: false, urlPath, method, statusCode: res.statusCode })
     }))
-    app.listen(options.METRICS_PORT, () => {
-      jsonLogger.info(`Metrics Server listening at http://localhost:${options.METRICS_PORT}`)
+    app.listen(options.port, () => {
+      jsonLogger.info(`Metrics Server listening at http://localhost:${options.port}`)
     })
     if (options.collectDefaultMetrics === true) {
       prometheus.collectDefaultMetrics()
     }
-    this.httpMetricsMiddleware = options.httpMetricsMiddleware
-    this.grpcMetricsInterceptor = options.grpcMetricsInterceptor
   }
 
-  get httpMiddleware () {
-    return this.httpMetricsMiddleware
+  httpMiddleware () {
+    return httpMetricsMiddleware
   }
 
-  get grpcInterceptor () {
-    return this.grpcMetricsInterceptor
+  grpcInterceptor () {
+    return grpcMetricsInterceptor
   }
 }
 
 export default Metrics
-export { httpMetricsMiddleware, grpcMetricsInterceptor }


### PR DESCRIPTION
- 量測時間可以換成 `process.hrtime()`，看起來更 pro，且延伸了一個小小知識點叫 Clock drift 
    - [stackoverflow code snippest](https://stackoverflow.com/a/14551263/8694937)
    - [`process.hrtime() `](https://nodejs.org/docs/v0.8.0/api/all.html#all_process_hrtime)
    - [Clock drift](https://en.wikipedia.org/wiki/Clock_drift)
- 知道你還要調 logger，但還是提醒一下 metrics package 裡面用相對路徑引用 logger 進來不是漂亮的做法，keep in mind 就好